### PR TITLE
Added Cybergrind Icon support

### DIFF
--- a/CarcassLoader/Plugin.cs
+++ b/CarcassLoader/Plugin.cs
@@ -1,6 +1,9 @@
 ﻿using BepInEx;
 using BepInEx.Configuration;
+using CarcassLoader.Assets;
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
@@ -19,6 +22,9 @@ namespace CarcassLoader
         public static Plugin Instance { get; private set; }
 
         private static Harmony harmony;
+
+        public static SpawnableObjectsDatabase CGIconsDatabase = new SpawnableObjectsDatabase();
+
         public static ConfigEntry<bool> EnableInCyberGrind { get; private set; }
         public static ConfigEntry<bool> EnableDebugTool { get; private set; }
 
@@ -41,6 +47,12 @@ namespace CarcassLoader
             Logger.LogInfo($"{PLUGIN_NAME} is loaded!");
             EnableInCyberGrind = Config.Bind<bool>("General", "EnableInCyberGrind", true, "Enables Carcass In Cybergrind");
             EnableDebugTool = Config.Bind<bool>("General", "EnableDebugTool", false, "Enables debug tool binds");
+
+            //Loads carcass into an easy to find database that cybergrind Icons can pick up.
+            //Even if the player has not visited the terminal or spawner arm
+            CGIconsDatabase.enemies = [];
+            var newEnemies = new List<SpawnableObject> { CarcassAssets.GetCarcassSpawnableObject() };
+            CGIconsDatabase.enemies = newEnemies.ToArray();
         }
 
     


### PR DESCRIPTION
Currently, when using Cybergrind Icons and Carcass, the icon appears white which makes it hard to tell if carcass is radiant, idol'd or both.

<img width="621" height="170" alt="image" src="https://github.com/user-attachments/assets/967b54f2-623c-447c-ab1f-44130f59ea7c" />

The reason behind the icon being white is due to the carcass spawnobject not being added to any database until the spawner arm or terminal has been opened for the first time. Most players playing the cybergrind wont open either of these, and it isn't made obvious that a fix is as easy as opening up the terminal before playing the cybergrind.

To fix the icon being white despite not opening the terminal or spawner arm, we just create a dummy database that includes only the carcass enemy. 
Since Cyber grind icons searches for ALL databases regardless of whether its used or where it's located, we can use this to add the carcass icon to a public unused database that CGIcons can find and use.

With this PR the icons will now look like this:

<img width="594" height="164" alt="image" src="https://github.com/user-attachments/assets/5fd3973c-587e-4480-82a1-7373f219f98f" />